### PR TITLE
Handling Network Latency for Typeahead search

### DIFF
--- a/app/javascript/controllers/form_controller.js
+++ b/app/javascript/controllers/form_controller.js
@@ -13,6 +13,7 @@ export default class extends Controller {
   }
 
   submit() {
+    this.submitTarget.disabled = false;
     this.submitTarget.click()
   }
 


### PR DESCRIPTION
See notes added to README.md. Needs a proper rebase before merge.