### PR TITLE
Fix absolute positioned mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ with the [link_to][] helper:
 
 Since the mentions are entirely String-based, they won't include any
 information related to a `User` record's identifier. We'll need to add
-support for resolveing records based on the `params[:id]` path
+support for resolving records based on the `params[:id]` path
 parameter.
 
 The generated `UsersController#set_user` helper method queries rows by
@@ -930,7 +930,6 @@ or on <kbd>escape</kbd>:
 +                                              action: "
 +                                                keydown->mentions#collapseOnEscape
 +                                                keydown->mentions#collapseOnCursorExit
-+                                                trix-blur->mentions#collapse
 +                                               " } %>
 
      <button form="new_mention" name="username" data-mentions-target="submit" hidden>Search</button>

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   include ActionText::Attachable
 
   scope :username_matching_handle, ->(handle) { where <<~SQL, handle.delete_prefix("@") + "%" }
-    username LIKE ?
+    username ILIKE ?
   SQL
 
   def to_trix_content_attachment_partial_path

--- a/app/views/messages/_form.html.erb
+++ b/app/views/messages/_form.html.erb
@@ -18,7 +18,6 @@
                                               action: "
                                                 keydown->mentions#collapseOnEscape
                                                 keydown->mentions#collapseOnCursorExit
-                                                trix-blur->mentions#collapse
                                                " } %>
 
     <button form="new_mention" name="username" data-mentions-target="submit" hidden>Search</button>


### PR DESCRIPTION
Currently mentions are positioned to show up under the cursor, however clicking on any of those mentions does not actually insert anything since the trix-blur event happens first. This fixes the issue by not collapsing on trix-blur.